### PR TITLE
Update README.md to fix Github json syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ yohe page <pageName>
 the command will create `<pageName>.md` file in `source/_extra` dir, the initial layout of the new page is `about`.
 
 ## config.json
-```json
+```js
 {
     "basic": {
         "title": "My Blog", // the title of your blog


### PR DESCRIPTION
Fix current `README.md` display:

<img width="925" alt="screen shot 2017-10-06 at 11 07 30 am" src="https://user-images.githubusercontent.com/3147296/31258975-92901030-aa86-11e7-9764-14b8621062ad.png">
